### PR TITLE
Restrict ACP module access to board administrators

### DIFF
--- a/acp/camosslimageproxy_info.php
+++ b/acp/camosslimageproxy_info.php
@@ -23,7 +23,7 @@ class camosslimageproxy_info
 			'version'	=> '1.1.0',
 			'modes'		=> array(
 				'config'	=> array('title' => 'ACP_CSIP_CONFIG', 
-									 'auth' => 'ext_phpbb/camosslimageproxy', 
+									 'auth' => 'ext_phpbb/camosslimageproxy && acl_a_board', 
 									 'cat'	=> array('CSIP_EXT')),
 			),
 		);


### PR DESCRIPTION
I changed the auth string for the settings module to only allow board administrators access. This prevents any unauthorized user from accessing the secret key and other settings.